### PR TITLE
LRU cache policy

### DIFF
--- a/list.go
+++ b/list.go
@@ -1,0 +1,225 @@
+package nicecache
+
+import (
+	"unsafe"
+)
+
+// Element is an element of a linked list.
+type Element struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev uintptr
+
+	// The list to which this element belongs.
+	list *List
+
+	// The value stored with this element.
+	KeyHash uint64
+}
+
+func (e *Element) nextElement() *Element {
+	return (*Element)(unsafe.Pointer(e.next))
+}
+
+func (e *Element) prevElement() *Element {
+	return (*Element)(unsafe.Pointer(e.prev))
+}
+
+func (e *Element) setNextElement(el *Element) {
+	e.next = uintptr(unsafe.Pointer(el))
+}
+
+func (e *Element) setPrevElement(el *Element) {
+	e.prev = uintptr(unsafe.Pointer(el))
+}
+
+// Next returns the next list element or nil.
+func (e *Element) Next() *Element {
+	if p := e.nextElement(); e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// Prev returns the previous list element or nil.
+func (e *Element) Prev() *Element {
+	if p := e.prevElement(); e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// List represents a doubly linked list.
+// The zero value for List is an empty list ready to use.
+type List struct {
+	root Element // sentinel list element, only &root, root.prev, and root.next are used
+	len  int     // current list length excluding (this) sentinel element
+}
+
+// Init initializes or clears list l.
+func (l *List) Init() *List {
+	l.root.setNextElement(&l.root)
+	l.root.setPrevElement(&l.root)
+	l.len = 0
+	return l
+}
+
+// New returns an initialized list.
+func New() *List { return new(List).Init() }
+
+// Len returns the number of elements of list l.
+// The complexity is O(1).
+func (l *List) Len() int { return l.len }
+
+// Front returns the first element of list l or nil.
+func (l *List) Front() *Element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.nextElement()
+}
+
+// Back returns the last element of list l or nil.
+func (l *List) Back() *Element {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prevElement()
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *List) lazyInit() {
+	if l.root.nextElement() == nil {
+		l.Init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *List) insert(e, at *Element) *Element {
+	n := at.nextElement()
+	at.setNextElement(e)
+	e.setPrevElement(at)
+	e.setNextElement(n)
+	n.setPrevElement(e)
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{KeyHash: v}, at).
+func (l *List) insertValue(v uint64, at *Element) *Element {
+	return l.insert(&Element{KeyHash: v}, at)
+}
+
+// remove removes e from its list, decrements l.len, and returns e.
+func (l *List) remove(e *Element) *Element {
+	e.prevElement().setNextElement(e.nextElement())
+	e.nextElement().setPrevElement(e.prevElement())
+	e.setNextElement(nil) // avoid memory leaks
+	e.setPrevElement(nil) // avoid memory leaks
+	e.list = nil
+	l.len--
+	return e
+}
+
+// Remove removes e from l if e is an element of list l.
+// It returns the element value e.KeyHash.
+func (l *List) Remove(e *Element) uint64 {
+	if e.list == l {
+		// if e.list == l, l must have been initialized when e was inserted
+		// in l or l == nil (e is a zero Element) and l.remove will crash
+		l.remove(e)
+	}
+	return e.KeyHash
+}
+
+// PushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *List) PushFront(v uint64) *Element {
+	l.lazyInit()
+	return l.insertValue(v, &l.root)
+}
+
+// PushBack inserts a new element e with value v at the back of list l and returns e.
+func (l *List) PushBack(v uint64) *Element {
+	l.lazyInit()
+	return l.insertValue(v, l.root.prevElement())
+}
+
+// InsertBefore inserts a new element e with value v immediately before mark and returns e.
+// If mark is not an element of l, the list is not modified.
+func (l *List) InsertBefore(v uint64, mark *Element) *Element {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark.prevElement())
+}
+
+// InsertAfter inserts a new element e with value v immediately after mark and returns e.
+// If mark is not an element of l, the list is not modified.
+func (l *List) InsertAfter(v uint64, mark *Element) *Element {
+	if mark.list != l {
+		return nil
+	}
+	// see comment in List.Remove about initialization of l
+	return l.insertValue(v, mark)
+}
+
+// MoveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+func (l *List) MoveToFront(e *Element) {
+	if e.list != l || l.root.nextElement() == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.insert(l.remove(e), &l.root)
+}
+
+// MoveToBack moves element e to the back of list l.
+// If e is not an element of l, the list is not modified.
+func (l *List) MoveToBack(e *Element) {
+	if e.list != l || l.root.prevElement() == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.insert(l.remove(e), l.root.prevElement())
+}
+
+// MoveBefore moves element e to its new position before mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+func (l *List) MoveBefore(e, mark *Element) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.insert(l.remove(e), mark.prevElement())
+}
+
+// MoveAfter moves element e to its new position after mark.
+// If e or mark is not an element of l, or e == mark, the list is not modified.
+func (l *List) MoveAfter(e, mark *Element) {
+	if e.list != l || e == mark || mark.list != l {
+		return
+	}
+	l.insert(l.remove(e), mark)
+}
+
+// PushBackList inserts a copy of an other list at the back of list l.
+// The lists l and other may be the same.
+func (l *List) PushBackList(other *List) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Front(); i > 0; i, e = i-1, e.Next() {
+		l.insertValue(e.KeyHash, l.root.prevElement())
+	}
+}
+
+// PushFrontList inserts a copy of an other list at the front of list l.
+// The lists l and other may be the same.
+func (l *List) PushFrontList(other *List) {
+	l.lazyInit()
+	for i, e := other.Len(), other.Back(); i > 0; i, e = i-1, e.Prev() {
+		l.insertValue(e.KeyHash, &l.root)
+	}
+}

--- a/list_benchmark_test.go
+++ b/list_benchmark_test.go
@@ -1,0 +1,22 @@
+package nicecache
+
+import (
+	"runtime"
+	"testing"
+)
+
+var l *List
+
+func BenchmarkList(t *testing.B) {
+	for j:=0; j<t.N; j++ {
+		l = New()
+
+		i := uint64(0)
+		for i < 10 {
+			l.PushFront(i)
+			i += 1
+		}
+	}
+
+	runtime.KeepAlive(l)
+}

--- a/list_test.go
+++ b/list_test.go
@@ -1,0 +1,337 @@
+package nicecache
+
+import "testing"
+
+func checkListLen(t *testing.T, l *List, len int) bool {
+	if n := l.Len(); n != len {
+		t.Errorf("l.Len() = %d, want %d", n, len)
+		return false
+	}
+	return true
+}
+
+func checkListPointers(t *testing.T, l *List, es []*Element) {
+	root := &l.root
+
+	if !checkListLen(t, l, len(es)) {
+		return
+	}
+
+	// zero length lists must be the zero value or properly initialized (sentinel circle)
+	if len(es) == 0 {
+		if l.root.nextElement() != nil && l.root.nextElement() != root || l.root.prevElement() != nil && l.root.prevElement() != root {
+			t.Errorf("l.root.nextElement() = %p, l.root.prevElement() = %p; both should both be nil or %p", l.root.nextElement(), l.root.prevElement(), root)
+		}
+		return
+	}
+	// len(es) > 0
+
+	// check internal and external prev/next connections
+	for i, e := range es {
+		prev := root
+		Prev := (*Element)(nil)
+		if i > 0 {
+			prev = es[i-1]
+			Prev = prev
+		}
+		if p := e.prevElement(); p != prev {
+			t.Errorf("elt[%d](%p).prevElement() = %p, want %p", i, e, p, prev)
+		}
+		if p := e.Prev(); p != Prev {
+			t.Errorf("elt[%d](%p).Prev() = %p, want %p", i, e, p, Prev)
+		}
+
+		next := root
+		Next := (*Element)(nil)
+		if i < len(es)-1 {
+			next = es[i+1]
+			Next = next
+		}
+		if n := e.nextElement(); n != next {
+			t.Errorf("elt[%d](%p).nextElement() = %p, want %p", i, e, n, next)
+		}
+		if n := e.Next(); n != Next {
+			t.Errorf("elt[%d](%p).Next() = %p, want %p", i, e, n, Next)
+		}
+	}
+}
+
+func TestList(t *testing.T) {
+	l := New()
+	checkListPointers(t, l, []*Element{})
+
+	// Single element list
+	e := l.PushFront(10)
+	checkListPointers(t, l, []*Element{e})
+	l.MoveToFront(e)
+	checkListPointers(t, l, []*Element{e})
+	l.MoveToBack(e)
+	checkListPointers(t, l, []*Element{e})
+	l.Remove(e)
+	checkListPointers(t, l, []*Element{})
+
+	// Bigger list
+	e2 := l.PushFront(2)
+	e1 := l.PushFront(1)
+	e3 := l.PushBack(3)
+	e4 := l.PushBack(11)
+	checkListPointers(t, l, []*Element{e1, e2, e3, e4})
+
+	l.Remove(e2)
+	checkListPointers(t, l, []*Element{e1, e3, e4})
+
+	l.MoveToFront(e3) // move from middle
+	checkListPointers(t, l, []*Element{e3, e1, e4})
+
+	l.MoveToFront(e1)
+	l.MoveToBack(e3) // move from middle
+	checkListPointers(t, l, []*Element{e1, e4, e3})
+
+	l.MoveToFront(e3) // move from back
+	checkListPointers(t, l, []*Element{e3, e1, e4})
+	l.MoveToFront(e3) // should be no-op
+	checkListPointers(t, l, []*Element{e3, e1, e4})
+
+	l.MoveToBack(e3) // move from front
+	checkListPointers(t, l, []*Element{e1, e4, e3})
+	l.MoveToBack(e3) // should be no-op
+	checkListPointers(t, l, []*Element{e1, e4, e3})
+
+	e2 = l.InsertBefore(2, e1) // insert before front
+	checkListPointers(t, l, []*Element{e2, e1, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore(2, e4) // insert before middle
+	checkListPointers(t, l, []*Element{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertBefore(2, e3) // insert before back
+	checkListPointers(t, l, []*Element{e1, e4, e2, e3})
+	l.Remove(e2)
+
+	e2 = l.InsertAfter(2, e1) // insert after front
+	checkListPointers(t, l, []*Element{e1, e2, e4, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter(2, e4) // insert after middle
+	checkListPointers(t, l, []*Element{e1, e4, e2, e3})
+	l.Remove(e2)
+	e2 = l.InsertAfter(2, e3) // insert after back
+	checkListPointers(t, l, []*Element{e1, e4, e3, e2})
+	l.Remove(e2)
+
+	// Check standard iteration.
+	sum := 0
+	for e := l.Front(); e != nil; e = e.Next() {
+		sum += int(e.KeyHash)
+	}
+	if sum != 15 {
+		t.Errorf("sum over l = %d, want 15", sum)
+	}
+
+	// Clear all elements by iterating
+	var next *Element
+	for e := l.Front(); e != nil; e = next {
+		next = e.Next()
+		l.Remove(e)
+	}
+	checkListPointers(t, l, []*Element{})
+}
+
+func checkList(t *testing.T, l *List, es []interface{}) {
+	if !checkListLen(t, l, len(es)) {
+		return
+	}
+
+	i := 0
+	for e := l.Front(); e != nil; e = e.Next() {
+		le := int(e.KeyHash)
+		if le != es[i] {
+			t.Errorf("elt[%d].KeyHash = %v, want %v", i, le, es[i])
+		}
+		i++
+	}
+}
+
+func TestExtending(t *testing.T) {
+	l1 := New()
+	l2 := New()
+
+	l1.PushBack(1)
+	l1.PushBack(2)
+	l1.PushBack(3)
+
+	l2.PushBack(4)
+	l2.PushBack(5)
+
+	l3 := New()
+	l3.PushBackList(l1)
+	checkList(t, l3, []interface{}{1, 2, 3})
+	l3.PushBackList(l2)
+	checkList(t, l3, []interface{}{1, 2, 3, 4, 5})
+
+	l3 = New()
+	l3.PushFrontList(l2)
+	checkList(t, l3, []interface{}{4, 5})
+	l3.PushFrontList(l1)
+	checkList(t, l3, []interface{}{1, 2, 3, 4, 5})
+
+	checkList(t, l1, []interface{}{1, 2, 3})
+	checkList(t, l2, []interface{}{4, 5})
+
+	l3 = New()
+	l3.PushBackList(l1)
+	checkList(t, l3, []interface{}{1, 2, 3})
+	l3.PushBackList(l3)
+	checkList(t, l3, []interface{}{1, 2, 3, 1, 2, 3})
+
+	l3 = New()
+	l3.PushFrontList(l1)
+	checkList(t, l3, []interface{}{1, 2, 3})
+	l3.PushFrontList(l3)
+	checkList(t, l3, []interface{}{1, 2, 3, 1, 2, 3})
+
+	l3 = New()
+	l1.PushBackList(l3)
+	checkList(t, l1, []interface{}{1, 2, 3})
+	l1.PushFrontList(l3)
+	checkList(t, l1, []interface{}{1, 2, 3})
+}
+
+func TestRemove(t *testing.T) {
+	l := New()
+	e1 := l.PushBack(1)
+	e2 := l.PushBack(2)
+	checkListPointers(t, l, []*Element{e1, e2})
+	e := l.Front()
+	l.Remove(e)
+	checkListPointers(t, l, []*Element{e2})
+	l.Remove(e)
+	checkListPointers(t, l, []*Element{e2})
+}
+
+func TestIssue4103(t *testing.T) {
+	l1 := New()
+	l1.PushBack(1)
+	l1.PushBack(2)
+
+	l2 := New()
+	l2.PushBack(3)
+	l2.PushBack(4)
+
+	e := l1.Front()
+	l2.Remove(e) // l2 should not change because e is not an element of l2
+	if n := l2.Len(); n != 2 {
+		t.Errorf("l2.Len() = %d, want 2", n)
+	}
+
+	l1.InsertBefore(8, e)
+	if n := l1.Len(); n != 3 {
+		t.Errorf("l1.Len() = %d, want 3", n)
+	}
+}
+
+func TestIssue6349(t *testing.T) {
+	l := New()
+	l.PushBack(1)
+	l.PushBack(2)
+
+	e := l.Front()
+	l.Remove(e)
+	if e.KeyHash != 1 {
+		t.Errorf("e.value = %d, want 1", e.KeyHash)
+	}
+	if e.Next() != nil {
+		t.Errorf("e.Next() != nil")
+	}
+	if e.Prev() != nil {
+		t.Errorf("e.Prev() != nil")
+	}
+}
+
+func TestMove(t *testing.T) {
+	l := New()
+	e1 := l.PushBack(1)
+	e2 := l.PushBack(2)
+	e3 := l.PushBack(3)
+	e4 := l.PushBack(4)
+
+	l.MoveAfter(e3, e3)
+	checkListPointers(t, l, []*Element{e1, e2, e3, e4})
+	l.MoveBefore(e2, e2)
+	checkListPointers(t, l, []*Element{e1, e2, e3, e4})
+
+	l.MoveAfter(e3, e2)
+	checkListPointers(t, l, []*Element{e1, e2, e3, e4})
+	l.MoveBefore(e2, e3)
+	checkListPointers(t, l, []*Element{e1, e2, e3, e4})
+
+	l.MoveBefore(e2, e4)
+	checkListPointers(t, l, []*Element{e1, e3, e2, e4})
+	e2, e3 = e3, e2
+
+	l.MoveBefore(e4, e1)
+	checkListPointers(t, l, []*Element{e4, e1, e2, e3})
+	e1, e2, e3, e4 = e4, e1, e2, e3
+
+	l.MoveAfter(e4, e1)
+	checkListPointers(t, l, []*Element{e1, e4, e2, e3})
+	e2, e3, e4 = e4, e2, e3
+
+	l.MoveAfter(e2, e3)
+	checkListPointers(t, l, []*Element{e1, e3, e2, e4})
+	e2, e3 = e3, e2
+}
+
+// Test PushFront, PushBack, PushFrontList, PushBackList with uninitialized List
+func TestZeroList(t *testing.T) {
+	var l1 = new(List)
+	l1.PushFront(1)
+	checkList(t, l1, []interface{}{1})
+
+	var l2 = new(List)
+	l2.PushBack(1)
+	checkList(t, l2, []interface{}{1})
+
+	var l3 = new(List)
+	l3.PushFrontList(l1)
+	checkList(t, l3, []interface{}{1})
+
+	var l4 = new(List)
+	l4.PushBackList(l2)
+	checkList(t, l4, []interface{}{1})
+}
+
+// Test that a list l is not modified when calling InsertBefore with a mark that is not an element of l.
+func TestInsertBeforeUnknownMark(t *testing.T) {
+	var l List
+	l.PushBack(1)
+	l.PushBack(2)
+	l.PushBack(3)
+	l.InsertBefore(1, new(Element))
+	checkList(t, &l, []interface{}{1, 2, 3})
+}
+
+// Test that a list l is not modified when calling InsertAfter with a mark that is not an element of l.
+func TestInsertAfterUnknownMark(t *testing.T) {
+	var l List
+	l.PushBack(1)
+	l.PushBack(2)
+	l.PushBack(3)
+	l.InsertAfter(1, new(Element))
+	checkList(t, &l, []interface{}{1, 2, 3})
+}
+
+// Test that a list l is not modified when calling MoveAfter or MoveBefore with a mark that is not an element of l.
+func TestMoveUnknownMark(t *testing.T) {
+	var l1 List
+	e1 := l1.PushBack(1)
+
+	var l2 List
+	e2 := l2.PushBack(2)
+
+	l1.MoveAfter(e1, e2)
+	checkList(t, &l1, []interface{}{1})
+	checkList(t, &l2, []interface{}{2})
+
+	l1.MoveBefore(e1, e2)
+	checkList(t, &l1, []interface{}{1})
+	checkList(t, &l2, []interface{}{2})
+}


### PR DESCRIPTION
This pull request implements an LRU cache policy in order to enhance cache performance for some cases

See https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_Recently_Used_.28LRU.29 for details

LRU caches are usually implemented by using doubly linked list. The majority of caching solutions available in go lang (e.g. https://github.com/lazada/go-cache) , afaik, have two
serious pitfalls:
1. They use interface{} as an underlying data type for storing cache entities
2. Self referential types used in doubly linked lists result in 2N pointers on the heap being allocated (which is not acceptable for fast caches as nicecache)

My proposals resolves both of the problems by using concrete types in the former case and by using unsafe.uptr in the latter.